### PR TITLE
TFS+3D LRT fix; PoP1 Apple II reset fix

### DIFF
--- a/pop1_apple.asl
+++ b/pop1_apple.asl
@@ -35,19 +35,11 @@ startup
             timer.CurrentTimingMethod = TimingMethod.GameTime;
         }
     }
-
-    vars.CurrentProcess = null;
-}
-
-update
-{
-    vars.OldProcess = vars.CurrentProcess;
-    vars.CurrentProcess = game;
 }
 
 start
 {
-    return(current.Level == 1 && current.Ticks == 0);
+    return (current.Level == 1 && current.Ticks == 0);
 }
 
 gameTime
@@ -64,7 +56,7 @@ gameTime
 
 reset
 {
-    return (current.Reset1 == 0 && current.Reset2 == 0 && current.Reset3 == 0) || vars.OldProcess != vars.CurrentProcess;
+    return (current.Reset1 == 0 && current.Reset2 == 0 && current.Reset3 == 0);
 }
 
 split

--- a/pop1_apple.asl
+++ b/pop1_apple.asl
@@ -35,6 +35,14 @@ startup
             timer.CurrentTimingMethod = TimingMethod.GameTime;
         }
     }
+
+    vars.CurrentProcess = null;
+}
+
+update
+{
+    vars.OldProcess = vars.CurrentProcess;
+    vars.CurrentProcess = game;
 }
 
 start
@@ -56,7 +64,7 @@ gameTime
 
 reset
 {
-    return((current.Reset1 == 0 && current.Reset2 == 0 && current.Reset3 == 0) || game.ProcessName != "AppleWin");
+    return (current.Reset1 == 0 && current.Reset2 == 0 && current.Reset3 == 0) || vars.OldProcess != vars.CurrentProcess;
 }
 
 split

--- a/pop_3d.asl
+++ b/pop_3d.asl
@@ -24,10 +24,11 @@ startup
     }
 }
 
-init
+exit
 {
-    vars.gameRunning = true;
-    game.Exited += (s, e) => vars.gameRunning = false;
+    // we do not need to unpause the IGT timer because the next time the game is running, the isLoading block will run and then it will be handled there
+    // however if we didn't have an isLoading block, then we would need to explicitly unpause in the init block
+    timer.IsGameTimePaused = true;
 }
 
 reset
@@ -46,7 +47,7 @@ start
 
 isLoading
 {
-    return (current.xPos == 0 && current.yPos == 0 && current.zPos == 0) || !vars.gameRunning;
+    return current.xPos == 0 && current.yPos == 0 && current.zPos == 0;
 }
 
 split

--- a/pop_tfs.asl
+++ b/pop_tfs.asl
@@ -135,9 +135,6 @@ startup
 
 init
 {
-    vars.gameRunning = true;
-    game.Exited += (s, e) => vars.gameRunning = false;
-
     // This is a split which triggers when the prince is within a certain range of coords
     vars.SplitTFSpos = (Func <int, int, int, int, bool>)((xTarg, yTarg, zTarg, range) => {
         return
@@ -157,9 +154,16 @@ init
     });
 }
 
+exit
+{
+    // we do not need to unpause the IGT timer because the next time the game is running, the isLoading block will run and then it will be handled there
+    // however if we didn't have an isLoading block, then we would need to explicitly unpause in the init block
+    timer.IsGameTimePaused = true;
+}
+
 isLoading
 {
-    return (current.isMenu == 0 || current.isLoading || !vars.gameRunning);
+    return (current.isMenu == 0 || current.isLoading);
 }
 
 reset


### PR DESCRIPTION
# TFS + 3D
We were subscribing to the `game.Exited` event but we never unsubscribed, which means that the ASL script object cannot be garbage collected until the process object is garbage collected. Although here in practice it (probably) doesn't cause a memory leak since as far as I know there is no case where the same process object is still alive while another ASL script object is created, it's still a bit dangerous because if (even in a future LiveSplit update) something references that process object, it will prevent the ASL script object from getting garbage collected as well.

Also, the script wasn't actually removing time when the game isn't running (though GMP tells me it worked before, so perhaps a new LiveSplit feature broke it?). For TFS this didn't matter because the other LRT conditions were already sufficient to freeze the timer when the game isn't running. I don't know if this made a difference for PoP 3D. Either way it's been fixed now.

# PoP1 Apple II
The reset condition that was based on the game not running was inefficient and also it wasn't working (perhaps also because of a LiveSplit update?). Instead of checking the process name string every cycle (which involves reading every character of a string, and potentially a system call), we now simply check if the process object itself has changed. This should add virtually no overhead.

# All
- TFS has been verified to work
- 3D hasn't been verified to work because I don't have the game, but the change is identical to TFS so it almost certainly works
- PoP1 Apple II hasn't been verified to work; ideally it should be verified to work in two ways:
  1. With the exact script that comes with this pull request
  2. With the script that comes with this pull request, but replacing the `reset` block with just `return vars.OldProcess != vars.CurrentProcess` to verify that that part of the script works correctly (since the other reset conditions may obscure whether this condition works or not)